### PR TITLE
Add indexes and optimize queries

### DIFF
--- a/turtle-backend/migrations/20241014074000_add_indexes.sql
+++ b/turtle-backend/migrations/20241014074000_add_indexes.sql
@@ -1,0 +1,2 @@
+CREATE UNIQUE INDEX IF NOT EXISTS idx_stories_date ON stories(date);
+CREATE INDEX IF NOT EXISTS idx_responses_created_at ON responses(created_at);


### PR DESCRIPTION
## Summary
- add migration to create indexes for `stories.date` and `responses.created_at`
- query stories by month using date range
- query responses by date using indexed column

## Testing
- `cargo check` *(fails: failed to download crates)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f03e9be14833083d69b6c771ff94a